### PR TITLE
Fix dashboard widget scheduled activities columns

### DIFF
--- a/modules/interventi/widgets/interventi_da_programmare.php
+++ b/modules/interventi/widgets/interventi_da_programmare.php
@@ -34,7 +34,6 @@ if (!empty($rs)) {
         <th width="70"><small>'.tr('Data richiesta').'</small></th>
         <th width="20%" class="text-center">'.tr('Tecnici assegnati').'</th>
         <th width="200">'.tr('Tipo intervento').'</th>
-        <th width="200">'.tr('Stato intervento').'</th>
         <th width="40"></th>
     </tr>';
 
@@ -74,7 +73,7 @@ if (!empty($rs)) {
             </tr>
             
             <tr style="display: none">
-                <td colspan="7">
+                <td colspan="6">
                     '.input([
             'type' => 'ckeditor',
             'name' => 'descrizione_'.$r->id,


### PR DESCRIPTION
### Motivation
- The dashboard widget that lists activities in the `TODO` state was showing a redundant `Stato intervento` column even though the widget already filters by that state, causing a mismatch between header columns and the detail row colspan.

### Description

- Updated `modules/interventi/widgets/interventi_da_programmare.php` to remove the extra `Stato intervento` table header and adjusted the detail row `colspan` from `7` to `6` so table layout is consistent; this addresses the visual/HTML mismatch and resolves the reported issue (`#1830`).

### Testing
- Ran `php -l modules/interventi/widgets/interventi_da_programmare.php` which reported no syntax errors (success). 
- Ran `git diff --check` which produced no whitespace/format issues (success). 
- Attempted to run `composer --no-interaction test -- --filter=NONE` but tests could not be executed in this environment because `vendor/autoload.php` is missing (environment dependency issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a218616e8f48324ba30b7aecb4a3ce8)