### PR TITLE
Fix filtro tipi attività in modifica sessione

### DIFF
--- a/modules/interventi/actions.php
+++ b/modules/interventi/actions.php
@@ -1224,6 +1224,23 @@ switch (post('op')) {
         }
 
         $id_tipo = post('id_tipo_interventot');
+        $anagrafica_tipo = $dbo->fetchOne('SELECT `an_anagrafiche`.`tipo`
+            FROM `in_interventi`
+            INNER JOIN `an_anagrafiche` ON `in_interventi`.`id_anagrafica` = `an_anagrafiche`.`id`
+            WHERE `in_interventi`.`id` = '.prepare($id_record));
+
+        if (!empty($anagrafica_tipo)) {
+            $tipologie_tipo_intervento = $dbo->fetchArray('SELECT `tipo`
+                FROM `in_tipi_intervento_tipologie`
+                WHERE `id_tipo_intervento` = '.prepare($id_tipo));
+            $tipologie_tipo_intervento = array_column($tipologie_tipo_intervento, 'tipo');
+
+            if (!empty($tipologie_tipo_intervento) && !in_array($anagrafica_tipo['tipo'], $tipologie_tipo_intervento)) {
+                flash()->error(tr('Il tipo attività selezionato non è compatibile con la tipologia dell\'anagrafica.'));
+                break;
+            }
+        }
+
         $sessione->setTipo($id_tipo);
 
         // Prezzi

--- a/modules/interventi/ajax/select.php
+++ b/modules/interventi/ajax/select.php
@@ -147,6 +147,14 @@ switch ($resource) {
         }
 
         $intervento = Intervento::find($id_intervento);
+        $id_anagrafica = $superselect['id_anagrafica'] ?? ($intervento->id_anagrafica ?? null);
+        $anagrafica_tipo = null;
+
+        if (!empty($id_anagrafica)) {
+            $anagrafica_tipo = $dbo->fetchOne('SELECT `tipo`
+                FROM `an_anagrafiche`
+                WHERE `id` = '.prepare($id_anagrafica));
+        }
 
         // Query per i tipi di intervento in base alla sede al contratto o al tecnico
         // Priorità: tariffe contratto > tariffe sede > tariffe tecnico
@@ -237,8 +245,39 @@ switch ($resource) {
         $rs = $data['results'];
 
         foreach ($rs as $k => $r) {
+            $disabled = false;
+
+            // Controllo se il tipo intervento è compatibile con la tipologia dell'anagrafica dell'attività
+            if (!empty($anagrafica_tipo)) {
+                $tipologie_tipo_intervento = $dbo->fetchArray('SELECT `tipo`
+                    FROM `in_tipi_intervento_tipologie`
+                    WHERE `id_tipo_intervento` = '.prepare($r['id']));
+
+                $tipologie_tipo_intervento = array_column($tipologie_tipo_intervento, 'tipo');
+                if (!empty($tipologie_tipo_intervento)) {
+                    $compatibile = in_array($anagrafica_tipo['tipo'], $tipologie_tipo_intervento);
+                    if (!$compatibile) {
+                        $disabled = true;
+                    }
+                }
+            }
+
+            // Controllo se il tipo intervento è compatibile con il gruppo utente
+            $gruppi_tipo_intervento = $dbo->fetchArray('SELECT `id_gruppo`
+                FROM `in_tipi_intervento_groups`
+                WHERE `id_tipo_intervento` = '.prepare($r['id']));
+
+            $gruppi_tipo_intervento = array_column($gruppi_tipo_intervento, 'id_gruppo');
+            if (!empty($gruppi_tipo_intervento)) {
+                $compatibile = in_array($id_gruppo, $gruppi_tipo_intervento);
+                if (!$compatibile) {
+                    $disabled = true;
+                }
+            }
+
             $rs[$k] = array_merge($r, [
                 'text' => $r['descrizione'],
+                'disabled' => $disabled,
             ]);
         }
 


### PR DESCRIPTION
### Motivation
- Risolve il comportamento descritto in #1823 evitando di mostrare o salvare tipi attività non compatibili con la tipologia dell'anagrafica collegata all'intervento.
- Allinea il filtro AJAX usato nella select `tipiintervento-tecnico` al comportamento della select principale e aggiunge il rispetto dei gruppi utente.

### Description
- Aggiornata `modules/interventi/ajax/select.php` per ricavare l'`id_anagrafica` dell'intervento e valutare, per ogni tipo, la compatibilità con le tipologie definite in `in_tipi_intervento_tipologie`; le opzioni non compatibili vengono restituite con `disabled: true` e viene mantenuto anche il controllo sui gruppi utente (`in_tipi_intervento_groups`).
- Aggiunta validazione lato server in `modules/interventi/actions.php` nella gestione `case 'edit_sessione'` che controlla la tipologia dell'anagrafica prima di applicare il tipo alla sessione e impedisce il salvataggio con un messaggio di errore se il tipo è incompatibile.
- Piccole modifiche per mantenere coerenza tra select client-side e filtro AJAX per il caso tecnico/integrazione contratto/sede.

### Testing
- Eseguiti controlli statici e di sintassi: `git diff --check` (nessun warning) succeeded, `php -l modules/interventi/ajax/select.php` succeeded, `php -l modules/interventi/actions.php` succeeded.
- Verificata la creazione del commit contenente le modifiche (`git log -1 --oneline`).
- Nota: i test unitari non sono stati eseguiti perché `vendor/` non è presente nell'ambiente e `phpunit` non è disponibile (automated PHPUnit run skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a218951b17483249ef1387df7f05e9b)