### PR TITLE
Migliora il widget dei preventivi in lavorazione

### DIFF
--- a/modules/preventivi/src/Preventivo.php
+++ b/modules/preventivi/src/Preventivo.php
@@ -193,6 +193,11 @@ class Preventivo extends Document
         return $this->belongsTo(Anagrafica::class, 'id_anagrafica');
     }
 
+    public function agente()
+    {
+        return $this->belongsTo(Anagrafica::class, 'id_agente');
+    }
+
     public function stato()
     {
         return $this->belongsTo(Stato::class, 'id_stato');

--- a/modules/preventivi/widgets/preventivi.dashboard.php
+++ b/modules/preventivi/widgets/preventivi.dashboard.php
@@ -19,21 +19,24 @@
  */
 
 include_once __DIR__.'/../../../core.php';
-use Models\Module;
 use Modules\Preventivi\Preventivo;
 use Modules\Preventivi\Stato;
 
-$id_module = Module::where('name', 'Preventivi')->first()->id;
+$rs = Preventivo::with(['agente', 'descrizioni', 'righe', 'articoli', 'sconti'])
+    ->where('id_stato', '=', Stato::where('name', 'In lavorazione')->first()->id)
+    ->where('default_revision', '=', 1)
+    ->get();
 
-$rs = Preventivo::where('id_stato', '=', Stato::where('name', 'In lavorazione')->first()->id)->where('default_revision', '=', 1)->get();
-
-if (!empty($rs)) {
+if ($rs->isNotEmpty()) {
     echo "
 <table class='table table-hover'>
     <tr>
-        <th width='70%'>Preventivo</th>
-        <th width='15%'>Data inizio</th>
-        <th width='15%'>Data conclusione</th>
+        <th>".tr('Preventivo')."</th>
+        <th>".tr('Cliente')."</th>
+        <th>".tr('Agente')."</th>
+        <th class='text-right'>".tr('Valore')."</th>
+        <th class='text-center'>".tr('Data inizio')."</th>
+        <th class='text-center'>".tr('Data conclusione')."</th>
     </tr>";
 
     foreach ($rs as $preventivo) {
@@ -46,9 +49,17 @@ if (!empty($rs)) {
             $attr = '';
         }
 
-        echo '<tr '.$attr.'><td><a href="'.base_path_osm().'/editor.php?id_module='.$id_module.'&id_record='.$preventivo->id.'">'.$preventivo->nome."</a><br><small class='help-block'>".$preventivo->ragione_sociale.'</small></td>';
-        echo '<td '.$attr.'>'.$data_accettazione.'</td>';
-        echo '<td '.$attr.'>'.$data_conclusione.'</td></tr>';
+        $cliente = $preventivo->anagrafica;
+        $agente = $preventivo->agente;
+
+        echo '<tr '.$attr.'>';
+        echo '<td>'.Modules::link('Preventivi', $preventivo->id, $preventivo->nome, true, null, false).'</td>';
+        echo '<td>'.(!empty($cliente) ? Modules::link('Anagrafiche', $cliente->id, $cliente->ragione_sociale, true, null, false) : '').'</td>';
+        echo '<td>'.(!empty($agente) ? Modules::link('Anagrafiche', $agente->id, $agente->ragione_sociale, true, null, false) : '').'</td>';
+        echo '<td class="text-right">'.moneyFormat($preventivo->totale, 2).'</td>';
+        echo '<td class="text-center">'.$data_accettazione.'</td>';
+        echo '<td class="text-center">'.$data_conclusione.'</td>';
+        echo '</tr>';
     }
 
     echo '


### PR DESCRIPTION
### Motivation
- Il widget "Preventivi in lavorazione" non mostrava agente e valore ed eseguiva query ripetute per ogni record causando carico aggiuntivo e peggiore esperienza utente.
- L'intervento mira a mostrare Cliente/Agente/Valore nel widget e ridurre le query con eager loading per eliminare il problema N+1 (issue #1814).

### Description
- Aggiunta la relazione `agente()` al modello `Modules\Preventivi\Preventivo` per collegare l'anagrafica indicata da `id_agente`.
- Aggiornato `modules/preventivi/widgets/preventivi.dashboard.php` per eseguire `Preventivo::with(['agente','descrizioni','righe','articoli','sconti'])` e includere le colonne `Preventivo`, `Cliente`, `Agente`, `Valore`, `Data inizio` e `Data conclusione` con link ai record.
- Il widget ora usa `Modules::link()` per i link ai record, `moneyFormat()` per il valore e `tr()` per le intestazioni, e verifica la presenza di risultati con `isNotEmpty()`.

### Testing
- Controllo sintassi PHP eseguito con `php -l modules/preventivi/widgets/preventivi.dashboard.php` ed è risultato OK.
- Controllo sintassi PHP eseguito con `php -l modules/preventivi/src/Preventivo.php` ed è risultato OK.
- Verificato con `git diff --check` per assicurare assenza di problemi di spaziatura/merge e non sono stati riscontrati errori.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a218c7704f08324853e700a01133a50)